### PR TITLE
Fixed a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ go-crond exposes [Prometheus][] metrics on `:8080/metrics` if enabled.
 |:----------------------------|:------------------------------------------------|
 | `gocrond_task_info`         | List of all cronjobs                            |
 | `gocrond_task_run_count`    | Counter for each executed task                  |
-| `gocrond_task_run_success`  | Last status (0=failed, 1=success) for each task |
+| `gocrond_task_run_result`  | Last status (0=failed, 1=success) for each task |
 | `gocrond_task_run_time`     | Last exec time (unix timestamp) for each task   |
 | `gocrond_task_run_duration` | Duration of last exec                           |
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ go-crond exposes [Prometheus][] metrics on `:8080/metrics` if enabled.
 |:----------------------------|:------------------------------------------------|
 | `gocrond_task_info`         | List of all cronjobs                            |
 | `gocrond_task_run_count`    | Counter for each executed task                  |
-| `gocrond_task_run_result`  | Last status (0=failed, 1=success) for each task |
+| `gocrond_task_run_result`   | Last status (0=failed, 1=success) for each task |
 | `gocrond_task_run_time`     | Last exec time (unix timestamp) for each task   |
 | `gocrond_task_run_duration` | Duration of last exec                           |
 


### PR DESCRIPTION
The metric run `go_crond_run_success` doesn't exist in the code, instead the 1 (success) or 0 (failure) is logged to `go_crond_run_result`